### PR TITLE
Makefile: Fix linking errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJS := $(TARGET).o
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) $^ -o $@
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Under both Linux and my Windows+MSYS2 environments, this fixes undefined
reference errors in libusb when linking final executable.

Signed-off-by: Daniel Silsby <dansilsby@gmail.com>